### PR TITLE
Fix: 내가 정의한 빈을 우선적으로 사용하게 변경

### DIFF
--- a/src/main/java/io/powerrangers/backend/service/CustomOauth2UserService.kt
+++ b/src/main/java/io/powerrangers/backend/service/CustomOauth2UserService.kt
@@ -4,6 +4,7 @@ import io.github.oshai.kotlinlogging.KotlinLogging
 import io.powerrangers.backend.dao.UserRepository
 import io.powerrangers.backend.entity.User
 import io.powerrangers.backend.utils.genUserDetails
+import org.springframework.context.annotation.Primary
 import org.springframework.security.oauth2.client.userinfo.DefaultOAuth2UserService
 import org.springframework.security.oauth2.client.userinfo.OAuth2UserRequest
 import org.springframework.security.oauth2.client.userinfo.OAuth2UserService
@@ -15,6 +16,7 @@ import java.util.*
 
 private val log = KotlinLogging.logger {}
 
+@Primary
 @Service
 class CustomOauth2UserService(
     private val userRepository: UserRepository,


### PR DESCRIPTION
## 🛰️ Issue Number
#71 

## 🪐 작업 내용
### 1. 원인
테스트를 진행하기 위해서 코드를 변경한 부분이 있었습니다. 
#### 변경 전
```java
@Service
class CustomOauth2UserService(
    private val userRepository: UserRepository
) : DefaultOAuth2UserService() {

        @Throws(OAuth2AuthenticationException::class)
        override fun loadUser(userRequest: OAuth2UserRequest): OAuth2User {
               val oAuth2User = super.loadUser(userRequest)
...
```
- `DefaultOAuth2UserService()` 을 상속해서 `super.loadUser()` 호출하는 방식이었습니다.
- 그런데 이렇게 작성하면 테스트할 때  `super.loadUser()` 을 mocking 해야 되는 상황에서 mocking 할 수 있는 방법이 없었습니다. 그래서 대안책으로 찾은 것이 의존성 주입을 받는 것이었습니다.
#### 변경 후
```java
@Service
class CustomOauth2UserService(
    private val userRepository: UserRepository,
    private val delegate: DefaultOAuth2UserService // 변경 지점
) : OAuth2UserService<OAuth2UserRequest, OAuth2User> {

    @Throws(OAuth2AuthenticationException::class)
    override fun loadUser(userRequest: OAuth2UserRequest): OAuth2User {
        val oAuth2User = delegate.loadUser(userRequest)
...
```
- 이렇게 되니 delegate 객체를 mocking 해서 테스트를 진행할 수 있었습니다. 그런데 이렇게 작성하니 oauth 로그인이 안되는 문제가 있었네요. 발생한 예외는 `ClassCastException` 이었습니다. 예외 메세지를 보니 `UserDetails`를 `DefaultOauth2User`로 casting 이 안된다는 것이었습니다. 
- 이상합니다. 제가 정의한 `CustomOauth2Service`를 사용하면 이런 일은 없어야 합니다. 원래 코드에서는 전혀 문제가 없던 예외가 생기는 것에 더해 원래 `Oauth2User` 타입이던 것이 `DefaultOauth2User` 가 된거지?
- 그래서 열심히 찾아본 결과 같은 빈이 2개가 등록되어 있어서 Spring 에서 사용하는 기본 빈이 사용되었다는 것입니다. 쉽게 말해 다음과 같이 같은 타입의 빈이 2개가 생긴것입니다.
```java
interface OAuth2UserService<OAuth2UserRequest, OAuth2User>

@Bean
fun defaultOauth2UserService(): OAuth2UserService<OAuth2UserRequest, OAuth2User> = DefaultOAuth2UserService()

@Bean
fun customOauth2UserService(): OAuth2UserService<OAuth2UserRequest, OAuth2User> = CustomOauth2UserService()
```
- Spring Framework 에서는 원래 같은 타입의 빈이 2개가 있다면 예외를 발생시키는데, Spring Boot AutoConfiguration 을 사용하면 기본 타입의 `defaultOauth2UserService()` 을 사용한다고 합니다. 그래서 관련 예외가 없던 것이었어요.
#### 결론
- 그래서 결론은 제가 만든 customOauth2UserService() 을 사용하게 강제하면 됩니다. 그래서 `@Primary` 을 사용해서 빈을  강제로 사용하게 했습니다.
- 가장 간편하게 할 수 있었고, 다른 방법도 있긴 한데,,, 안되더라고요. 그래서 이거 사용했습니다.
## 📚 Reference


## ✅ Check List
- [ ] 코드가 정상적으로 컴파일되나요?
- [ ] 테스트 코드를 통과했나요?
- [ ] merge할 브랜치의 위치를 확인했나요?
- [ ] Label을 지정했나요?