### PR TITLE
Refactor: BaseResponse 고도화

### DIFF
--- a/src/main/java/io/powerrangers/backend/controller/CommentController.kt
+++ b/src/main/java/io/powerrangers/backend/controller/CommentController.kt
@@ -17,13 +17,13 @@ class CommentController (
     private val commentService: CommentService
 ){
     @PostMapping
-    fun createComment(@RequestBody @Valid request: CommentCreateRequestDto): ResponseEntity<BaseResponse<CommentResponseDto>> {
+    fun createComment(@RequestBody @Valid request: CommentCreateRequestDto): ResponseEntity<BaseResponse.Success<CommentResponseDto>> {
         val response = commentService.createComment(request)
         return BaseResponse.success(HttpStatus.OK, response)
     }
 
     @GetMapping("/{taskId}")
-    fun getComments(@PathVariable taskId: Long): ResponseEntity<BaseResponse<List<CommentResponseDto>>> {
+    fun getComments(@PathVariable taskId: Long): ResponseEntity<BaseResponse.Success<List<CommentResponseDto>>> {
         val comments = commentService.getComments(taskId)
         return BaseResponse.success(HttpStatus.OK, comments)
     }
@@ -32,13 +32,13 @@ class CommentController (
     fun updateComment(
         @PathVariable commentId: Long,
         @RequestBody @Valid request: CommentUpdateRequestDto
-    ): ResponseEntity<BaseResponse<CommentUpdateResponseDto>> {
+    ): ResponseEntity<BaseResponse.Success<CommentUpdateResponseDto>> {
         val response = commentService.updateComment(commentId, request)
         return BaseResponse.success(HttpStatus.OK, response)
     }
 
     @DeleteMapping("/{commentId}")
-    fun deleteComment(@PathVariable commentId: Long): ResponseEntity<BaseResponse<Void>> {
+    fun deleteComment(@PathVariable commentId: Long): ResponseEntity<BaseResponse.Success<Nothing>> {
         commentService.deleteComment(commentId)
         return BaseResponse.success(HttpStatus.NO_CONTENT)
     }

--- a/src/main/java/io/powerrangers/backend/controller/FollowController.kt
+++ b/src/main/java/io/powerrangers/backend/controller/FollowController.kt
@@ -2,9 +2,7 @@ package io.powerrangers.backend.controller
 
 import io.powerrangers.backend.dto.*
 import io.powerrangers.backend.service.FollowService
-import io.powerrangers.backend.service.UserService
 import jakarta.validation.Valid
-import lombok.RequiredArgsConstructor
 import org.springframework.http.HttpStatus
 import org.springframework.http.ResponseEntity
 import org.springframework.web.bind.annotation.*
@@ -16,33 +14,33 @@ class FollowController(
 ) {
 
     @PostMapping
-    fun follow(@RequestBody followRequestDto: @Valid FollowRequestDto): ResponseEntity<BaseResponse<FollowResponseDto>> {
+    fun follow(@RequestBody followRequestDto: @Valid FollowRequestDto): ResponseEntity<BaseResponse.Success<FollowResponseDto>> {
         return BaseResponse.success(HttpStatus.CREATED, followService.follow(followRequestDto))
     }
 
     @DeleteMapping("/{followingId}")
-    fun unfollow(@PathVariable followingId: Long): ResponseEntity<BaseResponse<Void>> {
+    fun unfollow(@PathVariable followingId: Long): ResponseEntity<BaseResponse.Success<Nothing>> {
         followService.unfollow(followingId)
         return BaseResponse.success(HttpStatus.NO_CONTENT)
     }
 
     @GetMapping("/{userId}/followers")
-    fun getFollowers(@PathVariable userId: Long): ResponseEntity<BaseResponse<List<UserFollowResponseDto>>> {
+    fun getFollowers(@PathVariable userId: Long): ResponseEntity<BaseResponse.Success<List<UserFollowResponseDto>>> {
         return BaseResponse.success(HttpStatus.OK, followService.findFollowers(userId))
     }
 
     @GetMapping("/{userId}/followings")
-    fun getFollowings(@PathVariable userId: Long): ResponseEntity<BaseResponse<List<UserFollowResponseDto>>> {
+    fun getFollowings(@PathVariable userId: Long): ResponseEntity<BaseResponse.Success<List<UserFollowResponseDto>>> {
         return BaseResponse.success(HttpStatus.OK, followService.findFollowings(userId))
     }
 
     @GetMapping("/{userId}")
-    fun getFollowCount(@PathVariable userId: Long): ResponseEntity<BaseResponse<FollowCountResponseDto>> {
+    fun getFollowCount(@PathVariable userId: Long): ResponseEntity<BaseResponse.Success<FollowCountResponseDto>> {
         return BaseResponse.success(HttpStatus.OK, followService.getFollowCount(userId))
     }
 
     @GetMapping("/check")
-    fun checkFollowingRelationship(@RequestParam userId: Long): ResponseEntity<BaseResponse<FollowCheckResponseDto>> {
+    fun checkFollowingRelationship(@RequestParam userId: Long): ResponseEntity<BaseResponse.Success<FollowCheckResponseDto>> {
         return BaseResponse.success(HttpStatus.OK, followService.checkFollowingRelationship(userId))
     }
 }

--- a/src/main/java/io/powerrangers/backend/controller/TaskController.kt
+++ b/src/main/java/io/powerrangers/backend/controller/TaskController.kt
@@ -16,48 +16,48 @@ class TaskController(
 ) {
 
     @PostMapping
-    fun createTask(@Valid @RequestBody dto: TaskCreateRequestDto): ResponseEntity<BaseResponse<Void>> {
+    fun createTask(@Valid @RequestBody dto: TaskCreateRequestDto): ResponseEntity<BaseResponse.Success<Nothing>> {
         taskService.createTask(dto)
         return BaseResponse.success(HttpStatus.CREATED)
     }
 
     @PatchMapping("/{taskId}")
-    fun updateTask(@PathVariable taskId: Long, @Valid @RequestBody dto: TaskUpdateRequestDto): ResponseEntity<BaseResponse<Void>> {
+    fun updateTask(@PathVariable taskId: Long, @Valid @RequestBody dto: TaskUpdateRequestDto): ResponseEntity<BaseResponse.Success<Nothing>> {
         taskService.updateTask(taskId, dto)
         return BaseResponse.success(HttpStatus.OK)
     }
 
     @DeleteMapping("/{taskId}")
-    fun removeTask(@PathVariable taskId: Long): ResponseEntity<BaseResponse<Void>> {
+    fun removeTask(@PathVariable taskId: Long): ResponseEntity<BaseResponse.Success<Nothing>> {
         taskService.removeTask(taskId)
         return BaseResponse.success(HttpStatus.NO_CONTENT)
     }
 
     @PatchMapping("/{taskId}/status")
-    fun changeStatus(@PathVariable taskId: Long): ResponseEntity<BaseResponse<Void>> {
+    fun changeStatus(@PathVariable taskId: Long): ResponseEntity<BaseResponse.Success<Nothing>> {
         taskService.changeStatus(taskId)
         return BaseResponse.success(HttpStatus.OK)
     }
 
     @PatchMapping("/{taskId}/image")
     @Throws(IOException::class)
-    fun uploadImage(@RequestParam("image") file: MultipartFile, @PathVariable taskId: Long): ResponseEntity<BaseResponse<String>> {
+    fun uploadImage(@RequestParam("image") file: MultipartFile, @PathVariable taskId: Long): ResponseEntity<BaseResponse.Success<String>> {
         val imageUrl = taskService.uploadTaskImage(file, taskId)
         return BaseResponse.success(HttpStatus.OK, imageUrl)
     }
 
     @GetMapping("/{userId}/images")
-    fun getTaskImages(@PathVariable userId: Long): ResponseEntity<BaseResponse<List<TaskImageResponseDto>>> {
+    fun getTaskImages(@PathVariable userId: Long): ResponseEntity<BaseResponse.Success<List<TaskImageResponseDto>>> {
         return BaseResponse.success(HttpStatus.OK, taskService.getTaskImages(userId))
     }
 
     @GetMapping("/{taskId}")
-    fun getTask(@PathVariable taskId: Long): ResponseEntity<BaseResponse<TaskResponseDto>> {
+    fun getTask(@PathVariable taskId: Long): ResponseEntity<BaseResponse.Success<TaskResponseDto>> {
         return BaseResponse.success(HttpStatus.OK, taskService.getTask(taskId))
     }
 
     @PatchMapping("/{taskId}/postpone")
-    fun postpone(@PathVariable taskId: Long): ResponseEntity<BaseResponse<Void>> {
+    fun postpone(@PathVariable taskId: Long): ResponseEntity<BaseResponse.Success<Nothing>> {
         taskService.postpone(taskId)
         return BaseResponse.success(HttpStatus.OK)
     }
@@ -67,7 +67,7 @@ class TaskController(
         @RequestParam year: Int,
         @RequestParam month: Int,
         @RequestParam userId: Long
-    ): ResponseEntity<BaseResponse<TaskSummaryResponseDto>> {
+    ): ResponseEntity<BaseResponse.Success<TaskSummaryResponseDto>> {
         val result = taskService.getMonthlyTaskSummary(userId, year, month)
         return BaseResponse.success(HttpStatus.OK, result)
     }

--- a/src/main/java/io/powerrangers/backend/controller/UserController.kt
+++ b/src/main/java/io/powerrangers/backend/controller/UserController.kt
@@ -30,18 +30,18 @@ class UserController(
         @PathVariable userId: Long,
         @RequestPart(value = "image", required = false) image: MultipartFile?,
         @RequestPart(value = "dto") request: UserUpdateProfileRequestDto
-    ): ResponseEntity<BaseResponse<Void>> {
+    ): ResponseEntity<BaseResponse.Success<Nothing>> {
         userService.updateUserProfile(userId, request, image)
         return BaseResponse.success(HttpStatus.OK)
     }
 
     @GetMapping("/{userId}")
-    fun getUserProfile(@PathVariable userId: Long): ResponseEntity<BaseResponse<UserGetProfileResponseDto>> {
+    fun getUserProfile(@PathVariable userId: Long): ResponseEntity<BaseResponse.Success<UserGetProfileResponseDto>> {
         return BaseResponse.success(HttpStatus.OK, userService.getUserProfile(userId))
     }
 
     @GetMapping
-    fun searchUserProfile(@RequestParam nickname: String): ResponseEntity<BaseResponse<List<UserGetProfileResponseDto>>> {
+    fun searchUserProfile(@RequestParam nickname: String): ResponseEntity<BaseResponse.Success<List<UserGetProfileResponseDto>>> {
         return BaseResponse.success(
             HttpStatus.OK,
             userService.searchUserProfile(nickname)
@@ -49,7 +49,7 @@ class UserController(
     }
 
     @DeleteMapping("/{userId}")
-    fun cancelAccount(@PathVariable userId: Long): ResponseEntity<BaseResponse<Void>> {
+    fun cancelAccount(@PathVariable userId: Long): ResponseEntity<BaseResponse.Success<Nothing>> {
         userService.cancelAccount(userId)
         return BaseResponse.success(HttpStatus.NO_CONTENT)
     }
@@ -58,7 +58,7 @@ class UserController(
     fun getUserTasks(
         @PathVariable userId: Long,
         @RequestParam date: LocalDate
-    ): ResponseEntity<BaseResponse<List<TaskResponseDto>>> {
+    ): ResponseEntity<BaseResponse.Success<List<TaskResponseDto>>> {
         return BaseResponse.success(
             HttpStatus.OK,
             userService.getTasksByUser(userId, date)
@@ -66,7 +66,7 @@ class UserController(
     }
 
     @PostMapping("/logout")
-    fun logoutUser(): ResponseEntity<Void> {
+    fun logoutUser(): ResponseEntity<Nothing> {
         userService.logout()
         val deleteAccessCookie = deleteAccessCookie()
         val deleteRefreshCookie = deleteRefreshCookie()
@@ -74,7 +74,7 @@ class UserController(
         return ResponseEntity.ok()
             .header(HttpHeaders.SET_COOKIE, deleteAccessCookie.toString())
             .header(HttpHeaders.SET_COOKIE, deleteRefreshCookie.toString())
-            .build<Void>()
+            .build<Nothing>()
     }
 
     @PostMapping("/reissue")
@@ -89,7 +89,7 @@ class UserController(
     }
 
     @GetMapping("/me")
-    fun getMyId(): ResponseEntity<BaseResponse<Long>> {
+    fun getMyId(): ResponseEntity<BaseResponse.Success<Long>> {
         val userId = getCurrentUserId()
         return BaseResponse.success(HttpStatus.OK, userId)
     }

--- a/src/main/java/io/powerrangers/backend/dto/BaseResponse.kt
+++ b/src/main/java/io/powerrangers/backend/dto/BaseResponse.kt
@@ -3,27 +3,28 @@ package io.powerrangers.backend.dto
 import org.springframework.http.HttpStatus
 import org.springframework.http.ResponseEntity
 
-/***
- * ToDo: 에러메시지는 반환, 성공메시지를 삭제하기위해선 두가지 방법이 있어보인다.
- * 1. message필드를 제외한 성공 리스폰스와, 실패 리스폰스를 따로 관리.
- * 2. 필드를 유지하고 통합하여 관리하지만 성공 시 message null값 처리.
- * 일단은 2번이 더 적합하다고 판단하여 진행하였습니다!
- */
-data class BaseResponse<T> (
-    val status : Int,
-    val message : String?,
-    val data : T?
+sealed class BaseResponse<T>(
+    open val status: Int,
 ) {
+    data class Success<T>(
+        override val status: Int,
+        val data: T?,
+    ) : BaseResponse<T>(status)
+
+    data class Error<T>(
+        override val status: Int,
+        val message: String
+    ) : BaseResponse<T>(status)
 
     companion object {
-        fun <T> success(status: HttpStatus, data: T? = null): ResponseEntity<BaseResponse<T>> {
+        fun <T> success(status: HttpStatus, data: T? = null): ResponseEntity<Success<T>> {
             return ResponseEntity.status(status)
-                .body(BaseResponse(status.value(), null, data))
+                .body(Success(status.value(), data))
         }
 
-        fun <T> error(message: String? = null, status: HttpStatus, data: T? = null): ResponseEntity<BaseResponse<T>> {
+        fun <T> error(message: String, status: HttpStatus): ResponseEntity<Error<T>> {
             return ResponseEntity.status(status)
-                .body(BaseResponse(status.value(), message, data))
+                .body(Error(status.value(), message))
         }
     }
 }

--- a/src/main/java/io/powerrangers/backend/exception/GlobalExceptionHandler.kt
+++ b/src/main/java/io/powerrangers/backend/exception/GlobalExceptionHandler.kt
@@ -14,24 +14,24 @@ import java.io.IOException
 private val log = KotlinLogging.logger {}
 
 @RestControllerAdvice
-class GlobalExceptionHandler {
+open class GlobalExceptionHandler {
     @ExceptionHandler(CustomException::class)
-    protected fun handleCustomException(e: CustomException): ResponseEntity<BaseResponse<Void>> {
+    protected fun handleCustomException(e: CustomException): ResponseEntity<BaseResponse.Error<Nothing>> {
         return BaseResponse.error(e.errorCode.message, e.errorCode.status)
     }
 
     @ExceptionHandler(AuthTokenException::class)
-    protected fun handleAuthTokenException(e: AuthTokenException): ResponseEntity<BaseResponse<Void>> {
+    protected fun handleAuthTokenException(e: AuthTokenException): ResponseEntity<BaseResponse.Error<Nothing>> {
         return BaseResponse.error(e.errorCode.message, e.errorCode.status)
     }
 
     @ExceptionHandler(MethodArgumentNotValidException::class)
-    protected fun handleMethodArgumentNotValidException(e: MethodArgumentNotValidException): ResponseEntity<BaseResponse<Void>> {
+    protected fun handleMethodArgumentNotValidException(e: MethodArgumentNotValidException): ResponseEntity<BaseResponse.Error<Nothing>> {
         val fieldErrors = e.bindingResult.fieldErrors
 
-        val errorMessage = fieldErrors.map {
+        val errorMessage = fieldErrors.joinToString(", ") {
             "${it.field} : ${it.defaultMessage}"
-        }.joinToString(", ")
+        }
 
         val errorCode = ErrorCode.INVALID_REQUEST
 
@@ -39,30 +39,30 @@ class GlobalExceptionHandler {
     }
 
     @ExceptionHandler(HttpMessageNotReadableException::class)
-    protected fun handleHttpMessageNotReadableException(e: HttpMessageNotReadableException?): ResponseEntity<BaseResponse<Void>> {
+    protected fun handleHttpMessageNotReadableException(e: HttpMessageNotReadableException?): ResponseEntity<BaseResponse.Error<Nothing>> {
         return BaseResponse.error(ErrorCode.INVALID_REQUEST.message, ErrorCode.INVALID_REQUEST.status)
     }
 
     @ExceptionHandler(MissingServletRequestParameterException::class)
-    protected fun handleMissingServletRequestParameterException(e: MissingServletRequestParameterException?): ResponseEntity<BaseResponse<Void>> {
+    protected fun handleMissingServletRequestParameterException(e: MissingServletRequestParameterException?): ResponseEntity<BaseResponse.Error<Nothing>> {
         return BaseResponse.error(ErrorCode.INVALID_REQUEST.message, ErrorCode.INVALID_REQUEST.status)
     }
 
     @ExceptionHandler(MissingRequestCookieException::class)
-    protected fun handleMissingRequestCookieException(e: MissingRequestCookieException): ResponseEntity<BaseResponse<Void>> {
+    protected fun handleMissingRequestCookieException(e: MissingRequestCookieException): ResponseEntity<BaseResponse.Error<Nothing>> {
         log.warn { "[인증 실패] 토큰 쿠키가 존재하지 않음. 원인: ${e.message}" }
         return BaseResponse.error(ErrorCode.UNAUTHORIZED.message, ErrorCode.UNAUTHORIZED.status)
     }
 
     @ExceptionHandler(IOException::class)
-    protected fun handleIOException(e: IOException): ResponseEntity<BaseResponse<Void>> {
+    protected fun handleIOException(e: IOException): ResponseEntity<BaseResponse.Error<Nothing>> {
         val errorCode = ErrorCode.INTERNAL_SERVER_ERROR
         log.error(e) { "Unhandled I/O Exception occurred: ${e.message}" }
         return BaseResponse.error(errorCode.message, errorCode.status)
     }
 
     @ExceptionHandler(Exception::class)
-    protected fun handleException(e: Exception): ResponseEntity<BaseResponse<Void>> {
+    protected fun handleException(e: Exception): ResponseEntity<BaseResponse.Error<Nothing>> {
         val errorCode = ErrorCode.INTERNAL_SERVER_ERROR
         log.error(e) { "Unhandled Exception occurred: ${e.message}" }
         return BaseResponse.error(errorCode.message, errorCode.status)


### PR DESCRIPTION
## 🛰️ Issue Number
#73 

## 🪐 작업 내용
- 응답 객체를 Success, Error 객체로 나누어, 불필요한 필드가 없게 수정하였습니다.
- **이제 성공 객체에는 메세지가 없고, 예외 객체에는 data가 없습니다.**
```kotlin
sealed class BaseResponse<T>(
    open val status: Int,
) {
    data class Success<T>(
        override val status: Int,
        val data: T?,
    ) : BaseResponse<T>(status)

    data class Error<T>(
        override val status: Int,
        val message: String
    ) : BaseResponse<T>(status)

    companion object {
        fun <T> success(status: HttpStatus, data: T? = null): ResponseEntity<Success<T>> {
            return ResponseEntity.status(status)
                .body(Success(status.value(), data))
        }

        fun <T> error(message: String, status: HttpStatus): ResponseEntity<Error<T>> {
            return ResponseEntity.status(status)
                .body(Error(status.value(), message))
        }
    }
}
```
- sealed class 는 자바에서 abstract class 와 비슷한 역할을 하며, 인스턴스로 만들 수 없습니다.
- sealed class 안에 존재하는 data class 인 `Success`, `Error` 는 이를 상속한 객체로, 반드시 sealed class 내부에서만 정의될 수 있습니다. (다른 파일에서 `BaseResponse` 을 상속받는 클래스를 만들 수 없어, 한 파일에 정리할 수 있다는 장점이 있다고 합니다.)
### 응답 예시
- 위에서 언급한 것처럼 성공 객체에서 더 이상 message 가 없습니다.
```json
{
    "status": 200,
    "data": [
        {
            "id": 32,
            "category": "공부",
            "content": "스프링 공부하기",
            "dueDate": "2025-06-17T15:49:00",
            "status": "INCOMPLETE",
            "taskImage": null,
            "scope": "PRIVATE",
            "nickname": "tester"
        }
    ]
}
```
### 사용 예시
```kotlin
@PostMapping
    fun createComment(@RequestBody @Valid request: CommentCreateRequestDto): ResponseEntity<BaseResponse.Success<CommentResponseDto>> {
        val response = commentService.createComment(request)
        return BaseResponse.success(HttpStatus.OK, response)
    }
```
- 원래 의도했던 `ResponseEntity` 을 없애는 취지와 반대로.. 더 길어지긴 했지만 불필요한 필드를 없애는 게 더 중요하다고 생각해서 이렇게 진행했습니다.
### `ResponseEntity` 을 없애는 것을 포기한 이유
- 개인적으로 `ResponseEntity`를 사용하지 않고, `BaseResponse` 를 사용하고 싶었으나, 다음과 같은 이유로 포기했습니다.
1. `ResponseEntity` 와 동일한 기능을 제공하기 위해서는 `ResponseEntity` 에 존재하는 대부분의 메서드와 클래스를 가져와야 하는데, 굳이 그래야 하나? 라는 생각이 들었습니다. (배보다 배꼽이 더 큰 느낌?)
2. 스프링 어딘가에 `ResponseEntity` 을 사용하는 코드가 있다면 커스텀한 `BaseResponse` 을 사용하면 에러가 발생할 수도 있지 않을까 (뇌피셜입니다) 
## 📚 Reference


## ✅ Check List
- [x] 코드가 정상적으로 컴파일되나요?
- [x] 테스트 코드를 통과했나요?
- [x] merge할 브랜치의 위치를 확인했나요?
- [x] Label을 지정했나요?