### PR TITLE
Feat: RefreshToken 스케줄링 구현

### DIFF
--- a/src/main/java/io/powerrangers/backend/config/JpaAuditingConfiguration.kt
+++ b/src/main/java/io/powerrangers/backend/config/JpaAuditingConfiguration.kt
@@ -2,7 +2,9 @@ package io.powerrangers.backend.config
 
 import org.springframework.context.annotation.Configuration
 import org.springframework.data.jpa.repository.config.EnableJpaAuditing
+import org.springframework.scheduling.annotation.EnableScheduling
 
 @Configuration
 @EnableJpaAuditing
+@EnableScheduling
 class JpaAuditingConfiguration

--- a/src/main/java/io/powerrangers/backend/dao/RefreshTokenBlackListRepository.kt
+++ b/src/main/java/io/powerrangers/backend/dao/RefreshTokenBlackListRepository.kt
@@ -2,7 +2,11 @@ package io.powerrangers.backend.dao
 
 import io.powerrangers.backend.entity.RefreshTokenBlackList
 import org.springframework.data.jpa.repository.JpaRepository
+import org.springframework.data.jpa.repository.Modifying
+import java.time.LocalDateTime
 
 interface RefreshTokenBlackListRepository : JpaRepository<RefreshTokenBlackList, Long> {
     fun existsByRefreshToken_RefreshToken(refreshToken: String): Boolean
+    @Modifying
+    fun deleteByCreatedAtBefore(dateTime: LocalDateTime): Long
 }

--- a/src/main/java/io/powerrangers/backend/dao/RefreshTokenRepository.kt
+++ b/src/main/java/io/powerrangers/backend/dao/RefreshTokenRepository.kt
@@ -2,5 +2,10 @@ package io.powerrangers.backend.dao
 
 import io.powerrangers.backend.entity.RefreshToken
 import org.springframework.data.jpa.repository.JpaRepository
+import org.springframework.data.jpa.repository.Modifying
+import java.time.LocalDateTime
 
-interface RefreshTokenRepository : JpaRepository<RefreshToken, Long>
+interface RefreshTokenRepository : JpaRepository<RefreshToken, Long> {
+    @Modifying
+    fun deleteByCreatedAtBefore(dateTime: LocalDateTime): Long
+}

--- a/src/main/java/io/powerrangers/backend/dao/TokenRepository.kt
+++ b/src/main/java/io/powerrangers/backend/dao/TokenRepository.kt
@@ -3,7 +3,7 @@ package io.powerrangers.backend.dao
 import io.powerrangers.backend.entity.RefreshToken
 import io.powerrangers.backend.entity.RefreshTokenBlackList
 import io.powerrangers.backend.entity.User
-import java.util.*
+import java.time.LocalDateTime
 
 interface TokenRepository {
     fun save(user: User, refreshToken: String)
@@ -11,4 +11,5 @@ interface TokenRepository {
     fun addBlackList(refreshToken: RefreshToken): RefreshTokenBlackList
     fun findValidRefreshToken(userId: Long): RefreshToken?
     fun findAllRefreshTokensByUserId(userId: Long): List<RefreshToken>
+    fun cleanUpOldToken(dateTime: LocalDateTime)
 }

--- a/src/main/java/io/powerrangers/backend/dao/adapter/RefreshTokenRepositoryAdapter.kt
+++ b/src/main/java/io/powerrangers/backend/dao/adapter/RefreshTokenRepositoryAdapter.kt
@@ -9,6 +9,7 @@ import io.powerrangers.backend.entity.User
 import jakarta.persistence.EntityManager
 import org.springframework.stereotype.Repository
 import org.springframework.transaction.annotation.Transactional
+import java.time.LocalDateTime
 
 @Repository
 class RefreshTokenRepositoryAdapter (
@@ -21,7 +22,8 @@ class RefreshTokenRepositoryAdapter (
     override fun save(user: User, refreshToken: String) {
         val token = RefreshToken(
             user = user,
-            refreshToken = refreshToken
+            refreshToken = refreshToken,
+            createdAt = LocalDateTime.now()
         )
         refreshTokenRepository.save(token)
     }
@@ -34,7 +36,8 @@ class RefreshTokenRepositoryAdapter (
     @Transactional
     override fun addBlackList(refreshToken: RefreshToken): RefreshTokenBlackList {
         val blackList = RefreshTokenBlackList(
-            refreshToken = refreshToken
+            refreshToken = refreshToken,
+            createdAt = LocalDateTime.now()
         )
         return refreshTokenBlackListRepository.save(blackList)
     }
@@ -55,11 +58,17 @@ class RefreshTokenRepositoryAdapter (
             .orElse(null)
     }
 
-    @Transactional
+    @Transactional(readOnly = true)
     override fun findAllRefreshTokensByUserId(userId: Long): List<RefreshToken> {
         val jpql = "SELECT rt FROM RefreshToken rt WHERE rt.user.id = :userId"
         return entityManager.createQuery(jpql, RefreshToken::class.java)
             .setParameter("userId", userId)
             .resultList
+    }
+
+    @Transactional
+    override fun cleanUpOldToken(dateTime: LocalDateTime) {
+        refreshTokenBlackListRepository.deleteByCreatedAtBefore(dateTime)
+        refreshTokenRepository.deleteByCreatedAtBefore(dateTime)
     }
 }

--- a/src/main/java/io/powerrangers/backend/dao/adapter/RefreshTokenRepositoryAdapter.kt
+++ b/src/main/java/io/powerrangers/backend/dao/adapter/RefreshTokenRepositoryAdapter.kt
@@ -22,8 +22,7 @@ class RefreshTokenRepositoryAdapter (
     override fun save(user: User, refreshToken: String) {
         val token = RefreshToken(
             user = user,
-            refreshToken = refreshToken,
-            createdAt = LocalDateTime.now()
+            refreshToken = refreshToken
         )
         refreshTokenRepository.save(token)
     }
@@ -36,8 +35,7 @@ class RefreshTokenRepositoryAdapter (
     @Transactional
     override fun addBlackList(refreshToken: RefreshToken): RefreshTokenBlackList {
         val blackList = RefreshTokenBlackList(
-            refreshToken = refreshToken,
-            createdAt = LocalDateTime.now()
+            refreshToken = refreshToken
         )
         return refreshTokenBlackListRepository.save(blackList)
     }

--- a/src/main/java/io/powerrangers/backend/entity/RefreshToken.kt
+++ b/src/main/java/io/powerrangers/backend/entity/RefreshToken.kt
@@ -1,8 +1,16 @@
 package io.powerrangers.backend.entity
 
 import jakarta.persistence.*
+import org.springframework.data.annotation.CreatedDate
+import org.springframework.data.jpa.domain.support.AuditingEntityListener
+import java.time.LocalDateTime
 
 @Entity
+@Table(
+    name = "refresh_token",
+    indexes = [Index(name = "idx_refresh_token_created_at", columnList = "createdAt")]
+)
+@EntityListeners(AuditingEntityListener::class)
 class RefreshToken (
     @Id
     @Column(name = "refresh_token_id")
@@ -13,5 +21,9 @@ class RefreshToken (
     @JoinColumn(name = "user_id", nullable = true)
     var user: User?,
 
-    val refreshToken: String
+    val refreshToken: String,
+
+    @CreatedDate
+    @Column(name = "created_at", updatable = false)
+    val createdAt: LocalDateTime
 )

--- a/src/main/java/io/powerrangers/backend/entity/RefreshToken.kt
+++ b/src/main/java/io/powerrangers/backend/entity/RefreshToken.kt
@@ -21,9 +21,9 @@ class RefreshToken (
     @JoinColumn(name = "user_id", nullable = true)
     var user: User?,
 
-    val refreshToken: String,
-
+    val refreshToken: String
+) {
     @CreatedDate
     @Column(name = "created_at", updatable = false)
-    val createdAt: LocalDateTime
-)
+    var createdAt: LocalDateTime? = null
+}

--- a/src/main/java/io/powerrangers/backend/entity/RefreshTokenBlackList.kt
+++ b/src/main/java/io/powerrangers/backend/entity/RefreshTokenBlackList.kt
@@ -23,8 +23,8 @@ class RefreshTokenBlackList (
 
     @OneToOne
     var refreshToken: RefreshToken,
-
+) {
     @CreatedDate
     @Column(name = "created_at", updatable = false)
-    val createdAt: LocalDateTime
-)
+    var createdAt: LocalDateTime? = null
+}

--- a/src/main/java/io/powerrangers/backend/entity/RefreshTokenBlackList.kt
+++ b/src/main/java/io/powerrangers/backend/entity/RefreshTokenBlackList.kt
@@ -5,14 +5,26 @@ import lombok.AccessLevel
 import lombok.Builder
 import lombok.Getter
 import lombok.NoArgsConstructor
+import org.springframework.data.annotation.CreatedDate
+import org.springframework.data.jpa.domain.support.AuditingEntityListener
+import java.time.LocalDateTime
 
 @Entity
+@Table(
+    name = "refresh_token_black_list",
+    indexes = [Index(name = "idx_refresh_token_black_list_created_at", columnList = "createdAt")]
+)
+@EntityListeners(AuditingEntityListener::class)
 class RefreshTokenBlackList (
     @Id
-    @Column(name = "refresh_token__black_list_id")
+    @Column(name = "refresh_token_black_list_id")
     @GeneratedValue(strategy = GenerationType.IDENTITY)
     val id: Long? = null,
 
     @OneToOne
-    var refreshToken: RefreshToken
+    var refreshToken: RefreshToken,
+
+    @CreatedDate
+    @Column(name = "created_at", updatable = false)
+    val createdAt: LocalDateTime
 )

--- a/src/main/java/io/powerrangers/backend/service/TokenCleanupScheduler.kt
+++ b/src/main/java/io/powerrangers/backend/service/TokenCleanupScheduler.kt
@@ -1,0 +1,20 @@
+package io.powerrangers.backend.service
+
+import io.powerrangers.backend.dao.TokenRepository
+import org.springframework.beans.factory.annotation.Value
+import org.springframework.scheduling.annotation.Scheduled
+import org.springframework.stereotype.Service
+import java.time.Duration
+import java.time.LocalDateTime
+
+@Service
+class TokenCleanupScheduler(
+    private val tokenRepository: TokenRepository,
+    @Value("\${custom.jwt.validation.refresh}") private val expiredTime: Long
+) {
+    @Scheduled(cron = "0 0 3 * * *")
+    fun cleanUpOldToken() {
+        val threshold = LocalDateTime.now().minus(Duration.ofMillis(expiredTime))
+        tokenRepository.cleanUpOldToken(threshold)
+    }
+}

--- a/src/test/java/io/powerrangers/backend/dao/RefreshTokenRepositoryAdapterTests.kt
+++ b/src/test/java/io/powerrangers/backend/dao/RefreshTokenRepositoryAdapterTests.kt
@@ -7,6 +7,7 @@ import io.kotest.matchers.shouldNotBe
 import io.powerrangers.backend.dao.adapter.RefreshTokenRepositoryAdapter
 import io.powerrangers.backend.dto.Role
 import io.powerrangers.backend.entity.RefreshToken
+import io.powerrangers.backend.entity.RefreshTokenBlackList
 import io.powerrangers.backend.entity.User
 import jakarta.persistence.EntityManager
 import jakarta.persistence.PersistenceContext
@@ -15,6 +16,7 @@ import org.junit.jupiter.api.Test
 import org.springframework.beans.factory.annotation.Autowired
 import org.springframework.boot.test.autoconfigure.orm.jpa.DataJpaTest
 import org.springframework.context.annotation.Import
+import java.time.LocalDateTime
 
 @DataJpaTest
 @Import(RefreshTokenRepositoryAdapter::class)
@@ -66,7 +68,8 @@ class RefreshTokenRepositoryAdapterTests {
 
         val refreshToken = RefreshToken(
             user = user,
-            refreshToken = "bad-token"
+            refreshToken = "bad-token",
+            createdAt = LocalDateTime.now()
         )
 
         refreshTokenRepository.save(refreshToken)
@@ -87,8 +90,8 @@ class RefreshTokenRepositoryAdapterTests {
         val user = genUser()
         em.persist(user)
 
-        val token1 = RefreshToken(user = user, refreshToken = "token-1")
-        val token2 = RefreshToken(user = user, refreshToken = "token-2")
+        val token1 = RefreshToken(user = user, refreshToken = "token-1", createdAt = LocalDateTime.now())
+        val token2 = RefreshToken(user = user, refreshToken = "token-2", createdAt = LocalDateTime.now())
         em.persist(token1)
         em.persist(token2)
 
@@ -100,6 +103,47 @@ class RefreshTokenRepositoryAdapterTests {
         tokens shouldHaveSize 2
         tokens.map { it.refreshToken } shouldContainAll listOf("token-1", "token-2")
     }
+
+    @Test
+    fun `createdAt 기준으로 threshold 보다 오래된 refreshToken을 삭제할 수 있다`() {
+        val user = genUser()
+        val currentTime = LocalDateTime.now()
+        val invalid = RefreshToken(user = user, refreshToken = "invalid", createdAt = currentTime.minusDays(2))
+        val valid = RefreshToken(user = user, refreshToken = "valid", createdAt = currentTime)
+        em.persist(user)
+        em.persist(invalid)
+        em.persist(valid)
+
+        em.flush()
+        em.clear()
+
+        val count = refreshTokenRepository.deleteByCreatedAtBefore(currentTime.minusHours(1))
+
+        count shouldBe 1
+    }
+
+    @Test
+    fun `createdAt 기준으로 threshold 보다 오래된 refreshTokenBlackList을 삭제할 수 있다`() {
+        val user = genUser()
+        val currentTime = LocalDateTime.now()
+        val dummyToken1 = RefreshToken(user = user, refreshToken = "dummy1", createdAt = currentTime)
+        val dummyToken2 = RefreshToken(user = user, refreshToken = "dummy2", createdAt = currentTime)
+        val invalid = RefreshTokenBlackList(refreshToken = dummyToken1, createdAt = currentTime.minusDays(2))
+        val valid = RefreshTokenBlackList(refreshToken = dummyToken2, createdAt = currentTime)
+        em.persist(user)
+        em.persist(dummyToken1)
+        em.persist(dummyToken2)
+        em.persist(invalid)
+        em.persist(valid)
+
+        em.flush()
+        em.clear()
+
+        val count = refreshTokenBlackListRepository.deleteByCreatedAtBefore(currentTime.minusHours(1))
+
+        count shouldBe 1
+    }
+
 
     private fun genUser(): User {
         return User(

--- a/src/test/java/io/powerrangers/backend/dao/RefreshTokenRepositoryAdapterTests.kt
+++ b/src/test/java/io/powerrangers/backend/dao/RefreshTokenRepositoryAdapterTests.kt
@@ -9,7 +9,6 @@ import io.powerrangers.backend.dto.Role
 import io.powerrangers.backend.entity.RefreshToken
 import io.powerrangers.backend.entity.RefreshTokenBlackList
 import io.powerrangers.backend.entity.User
-import io.powerrangers.backend.service.targetUserId
 import jakarta.persistence.EntityManager
 import jakarta.persistence.PersistenceContext
 import org.junit.jupiter.api.BeforeEach
@@ -17,7 +16,6 @@ import org.junit.jupiter.api.Test
 import org.springframework.beans.factory.annotation.Autowired
 import org.springframework.boot.test.autoconfigure.orm.jpa.DataJpaTest
 import org.springframework.context.annotation.Import
-import org.springframework.test.util.ReflectionTestUtils
 import java.time.LocalDateTime
 
 @DataJpaTest
@@ -111,8 +109,7 @@ class RefreshTokenRepositoryAdapterTests {
         val currentTime = LocalDateTime.now()
         val invalid = RefreshToken(user = user, refreshToken = "invalid")
         val valid = RefreshToken(user = user, refreshToken = "valid")
-        ReflectionTestUtils.setField(invalid, "createdAt", currentTime.minusDays(2))
-        ReflectionTestUtils.setField(valid, "createdAt", currentTime)
+
         em.persist(user)
         em.persist(invalid)
         em.persist(valid)
@@ -120,7 +117,15 @@ class RefreshTokenRepositoryAdapterTests {
         em.flush()
         em.clear()
 
-        val count = refreshTokenRepository.deleteByCreatedAtBefore(currentTime)
+        em.createQuery("update RefreshToken r set r.createdAt=:t where r.refreshToken='invalid'")
+            .setParameter("t", currentTime.minusDays(2))
+            .executeUpdate()
+        em.createQuery("update RefreshToken r set r.createdAt=:t where r.refreshToken='valid'")
+            .setParameter("t", currentTime)
+            .executeUpdate()
+
+        em.clear()
+        val count = refreshTokenRepository.deleteByCreatedAtBefore(currentTime.minusHours(1))
 
         count shouldBe 1
     }
@@ -134,19 +139,25 @@ class RefreshTokenRepositoryAdapterTests {
         val invalid = RefreshTokenBlackList(refreshToken = dummyToken1)
         val valid = RefreshTokenBlackList(refreshToken = dummyToken2)
 
-        ReflectionTestUtils.setField(invalid, "createdAt", currentTime.minusDays(2))
-        ReflectionTestUtils.setField(valid, "createdAt", currentTime)
-
         em.persist(user)
         em.persist(dummyToken1)
         em.persist(dummyToken2)
-        em.persist(invalid)
+        em.persist(invalid);
         em.persist(valid)
 
         em.flush()
         em.clear()
 
-        val count = refreshTokenBlackListRepository.deleteByCreatedAtBefore(currentTime)
+        em.createQuery("update RefreshTokenBlackList b set b.createdAt = :t where b.refreshToken.refreshToken = 'dummy1'")
+            .setParameter("t", currentTime.minusDays(2))
+            .executeUpdate()
+
+        em.createQuery("update RefreshTokenBlackList b set b.createdAt = :t where b.refreshToken.refreshToken = 'dummy2'")
+            .setParameter("t", currentTime)
+            .executeUpdate()
+
+        em.clear()
+        val count = refreshTokenBlackListRepository.deleteByCreatedAtBefore(currentTime.minusHours(1))
 
         count shouldBe 1
     }

--- a/src/test/java/io/powerrangers/backend/dao/RefreshTokenRepositoryAdapterTests.kt
+++ b/src/test/java/io/powerrangers/backend/dao/RefreshTokenRepositoryAdapterTests.kt
@@ -9,6 +9,7 @@ import io.powerrangers.backend.dto.Role
 import io.powerrangers.backend.entity.RefreshToken
 import io.powerrangers.backend.entity.RefreshTokenBlackList
 import io.powerrangers.backend.entity.User
+import io.powerrangers.backend.service.targetUserId
 import jakarta.persistence.EntityManager
 import jakarta.persistence.PersistenceContext
 import org.junit.jupiter.api.BeforeEach
@@ -16,6 +17,7 @@ import org.junit.jupiter.api.Test
 import org.springframework.beans.factory.annotation.Autowired
 import org.springframework.boot.test.autoconfigure.orm.jpa.DataJpaTest
 import org.springframework.context.annotation.Import
+import org.springframework.test.util.ReflectionTestUtils
 import java.time.LocalDateTime
 
 @DataJpaTest
@@ -68,8 +70,7 @@ class RefreshTokenRepositoryAdapterTests {
 
         val refreshToken = RefreshToken(
             user = user,
-            refreshToken = "bad-token",
-            createdAt = LocalDateTime.now()
+            refreshToken = "bad-token"
         )
 
         refreshTokenRepository.save(refreshToken)
@@ -90,8 +91,8 @@ class RefreshTokenRepositoryAdapterTests {
         val user = genUser()
         em.persist(user)
 
-        val token1 = RefreshToken(user = user, refreshToken = "token-1", createdAt = LocalDateTime.now())
-        val token2 = RefreshToken(user = user, refreshToken = "token-2", createdAt = LocalDateTime.now())
+        val token1 = RefreshToken(user = user, refreshToken = "token-1")
+        val token2 = RefreshToken(user = user, refreshToken = "token-2")
         em.persist(token1)
         em.persist(token2)
 
@@ -108,8 +109,10 @@ class RefreshTokenRepositoryAdapterTests {
     fun `createdAt 기준으로 threshold 보다 오래된 refreshToken을 삭제할 수 있다`() {
         val user = genUser()
         val currentTime = LocalDateTime.now()
-        val invalid = RefreshToken(user = user, refreshToken = "invalid", createdAt = currentTime.minusDays(2))
-        val valid = RefreshToken(user = user, refreshToken = "valid", createdAt = currentTime)
+        val invalid = RefreshToken(user = user, refreshToken = "invalid")
+        val valid = RefreshToken(user = user, refreshToken = "valid")
+        ReflectionTestUtils.setField(invalid, "createdAt", currentTime.minusDays(2))
+        ReflectionTestUtils.setField(valid, "createdAt", currentTime)
         em.persist(user)
         em.persist(invalid)
         em.persist(valid)
@@ -117,7 +120,7 @@ class RefreshTokenRepositoryAdapterTests {
         em.flush()
         em.clear()
 
-        val count = refreshTokenRepository.deleteByCreatedAtBefore(currentTime.minusHours(1))
+        val count = refreshTokenRepository.deleteByCreatedAtBefore(currentTime)
 
         count shouldBe 1
     }
@@ -126,10 +129,14 @@ class RefreshTokenRepositoryAdapterTests {
     fun `createdAt 기준으로 threshold 보다 오래된 refreshTokenBlackList을 삭제할 수 있다`() {
         val user = genUser()
         val currentTime = LocalDateTime.now()
-        val dummyToken1 = RefreshToken(user = user, refreshToken = "dummy1", createdAt = currentTime)
-        val dummyToken2 = RefreshToken(user = user, refreshToken = "dummy2", createdAt = currentTime)
-        val invalid = RefreshTokenBlackList(refreshToken = dummyToken1, createdAt = currentTime.minusDays(2))
-        val valid = RefreshTokenBlackList(refreshToken = dummyToken2, createdAt = currentTime)
+        val dummyToken1 = RefreshToken(user = user, refreshToken = "dummy1")
+        val dummyToken2 = RefreshToken(user = user, refreshToken = "dummy2")
+        val invalid = RefreshTokenBlackList(refreshToken = dummyToken1)
+        val valid = RefreshTokenBlackList(refreshToken = dummyToken2)
+
+        ReflectionTestUtils.setField(invalid, "createdAt", currentTime.minusDays(2))
+        ReflectionTestUtils.setField(valid, "createdAt", currentTime)
+
         em.persist(user)
         em.persist(dummyToken1)
         em.persist(dummyToken2)
@@ -139,7 +146,7 @@ class RefreshTokenRepositoryAdapterTests {
         em.flush()
         em.clear()
 
-        val count = refreshTokenBlackListRepository.deleteByCreatedAtBefore(currentTime.minusHours(1))
+        val count = refreshTokenBlackListRepository.deleteByCreatedAtBefore(currentTime)
 
         count shouldBe 1
     }


### PR DESCRIPTION
## 🛰️ Issue Number
#78 

## 🪐 작업 내용
### 변경점
- RefreshToken, RefreshTokenBlackList 의 생성 시간을 추적해야 되서 createdAt 필드를 추가했습니다.
- RefreshToken, RefreshTokenBlackList 에 createdAt 을 이용한 index를 추가했습니다. createdAt은 변경되지 않으며, 많은 양의 토큰이 DB에 저장될 것으로 예상되었기 때문에 index를 도입해도 괜찮겠다고 생각했습니다.
### 작업 내용
- RefreshToken, RefreshTokenBlackList 을 스케줄링을 통해 지울 수 있게 구현했습니다.
- 관련 테스트도 같이 진행했습니다. 

## 📚 Reference


## ✅ Check List
- [x] 코드가 정상적으로 컴파일되나요?
- [x] 테스트 코드를 통과했나요?
- [x] merge할 브랜치의 위치를 확인했나요?
- [x] Label을 지정했나요?