### PR TITLE
Fix : PR 실패 시에도 슬랙 알람 가도록 수정

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -62,13 +62,14 @@ jobs:
   slack-notify:
     needs: build-and-test
     runs-on: ubuntu-latest
+    if : always()
     permissions:
         contents: read
 
     steps:
 
       - name: Notify Slack on Success
-        if: success() # 이 step은 job이 성공한 경우에만 실행된다.
+        if: needs.build-and-test.result == 'success' # 이 step은 job이 성공한 경우에만 실행된다.
         id: slack-success
         uses: rtCamp/action-slack-notify@v2
         env:
@@ -84,7 +85,7 @@ jobs:
             ${{ github.event_name == 'pull_request' && format('PR 제목: {0}', github.event.pull_request.title) || '' }}
 
       - name: Notify Slack on Failure
-        if: failure() # 이 step은 job이 실패한 경우에만 실행됩니다.
+        if: needs.build-and-test.result == 'failure' # 이 step은 job이 실패한 경우에만 실행됩니다.
         id: slack-failure
         uses: rtCamp/action-slack-notify@v2
         env:


### PR DESCRIPTION
## 🛰️ Issue Number
- #83 

## 🪐 작업 내용
- 태호님 PR이 실패했는데, 슬랙이 알람이 안오길래 확인해보니, 실패했을 때는 처리가 안되게끔 되어있네요.
- 그래서 이 부분 후딱 수정했습니다. 

## 📚 Reference


## ✅ Check List
- [x] 코드가 정상적으로 컴파일되나요?
- [x] 테스트 코드를 통과했나요?
- [x] merge할 브랜치의 위치를 확인했나요?
- [x] Label을 지정했나요?