### PR TITLE
Feat: 도커에 DB, 프로젝트 컨테이너 띄워서 실행하기 

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -37,3 +37,6 @@ out/
 .vscode/
 src/main/resources/application.yml
 src/test/resources/application.yml
+
+*.tar
+.env

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,9 @@
+FROM eclipse-temurin:21-jdk
+
+WORKDIR /app
+
+COPY build/libs/backend-0.0.1-SNAPSHOT.jar app.jar
+COPY wait-for-it.sh wait-for-it.sh
+RUN chmod +x wait-for-it.sh
+
+ENTRYPOINT ["./wait-for-it.sh", "db:3306", "--", "java", "-jar", "app.jar"]

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,0 +1,27 @@
+version: "3"
+services:
+  db:
+    image: mysql:8.0
+    container_name: mysql-dev-container
+    environment:
+      MYSQL_ROOT_PASSWORD: "${MYSQL_ROOT_PASSWORD}"
+      MYSQL_DATABASE: "${MYSQL_DATABASE}"
+      MYSQL_USER: "${MYSQL_USER}"
+      MYSQL_PASSWORD: "${MYSQL_PASSWORD}"
+    ports:
+      - "3305:3306"
+    networks:
+      - spring-network
+
+  app:
+    build: .
+    container_name: backend-app
+    depends_on:
+      - db
+    ports:
+      - "8080:8080"
+    networks:
+      - spring-network
+
+networks:
+  spring-network:


### PR DESCRIPTION
## 🛰️ Issue Number
- #80 

## 🪐 작업 내용
- 도커에 띄울 컨테이너들을 하나의 컨테이너 환경으로 만들고, Dockerfile도 작성하여 프로젝트를 이미지화했습니다.
- EC2 자체에서 프로젝트 빌드 -> 도커 컨테이너 빌드를 했을 땐 정상적으로 잘 작동하는 것을 확인했습니다. 

## 📚 Reference


## ✅ Check List
- [x] 코드가 정상적으로 컴파일되나요?
- [x] 테스트 코드를 통과했나요?
- [x] merge할 브랜치의 위치를 확인했나요?
- [x] Label을 지정했나요?